### PR TITLE
Implement redis driven quote endpoint via tdd

### DIFF
--- a/backend/app/core/kb_loader.py
+++ b/backend/app/core/kb_loader.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+
+def _load_json_from_kb(filename: str) -> list[dict]:
+    """
+    Loads and parses a JSON file from the knowledge_base directory.
+    """
+    root_dir = Path(__file__).parent.parent.parent
+    json_path = root_dir / "knowledge_base" / filename
+
+    try:
+        with open(json_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data
+    except FileNotFoundError:
+        return []
+
+
+FALLBACK_QUOTES = _load_json_from_kb("quotes.json")

--- a/backend/app/routers/quotes.py
+++ b/backend/app/routers/quotes.py
@@ -1,7 +1,9 @@
 import random
+import json
 from fastapi import APIRouter, Request
 from app.dependencies import limiter
 from app.config import QUOTES_RATE_LIMIT
+from app.core.redis_client import redis_client
 
 router = APIRouter()
 
@@ -28,4 +30,9 @@ def get_random_quote(request: Request):
     Returns a single random quote from the static list.
     This endpoint is rate-limited.
     """
+    cached_quote_string = redis_client.lpop("quotes")
+
+    if cached_quote_string:
+        return json.loads(cached_quote_string)
+
     return random.choice(quotes)

--- a/backend/app/routers/quotes.py
+++ b/backend/app/routers/quotes.py
@@ -4,23 +4,9 @@ from fastapi import APIRouter, Request
 from app.dependencies import limiter
 from app.config import QUOTES_RATE_LIMIT
 from app.core.redis_client import redis_client
+from app.core.kb_loader import FALLBACK_QUOTES
 
 router = APIRouter()
-
-quotes = [
-    {
-        "author": "Albert Einstein",
-        "text": "Strive not to be a success, but rather to be of value.",
-    },
-    {
-        "author": "Steve Jobs",
-        "text": "Your time is limited, so don't waste it living someone else's life.",
-    },
-    {
-        "author": "Mark Twain",
-        "text": "The secret of getting ahead is getting started.",
-    },
-]
 
 
 @router.get("/quote", tags=["quotes"])
@@ -30,9 +16,9 @@ def get_random_quote(request: Request):
     Returns a single random quote from the static list.
     This endpoint is rate-limited.
     """
-    cached_quote_string = redis_client.lpop("quotes")
+    cached_quote_string = redis_client.srandmember("quotes")
 
     if cached_quote_string:
         return json.loads(cached_quote_string)
 
-    return random.choice(quotes)
+    return random.choice(FALLBACK_QUOTES)

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -3,6 +3,7 @@
 pytest
 pytest-cov
 pytest-asyncio
+pytest-mock
 httpx
 
 ruff

--- a/backend/tests/routers/test_quotes.py
+++ b/backend/tests/routers/test_quotes.py
@@ -4,27 +4,42 @@ from app.core.redis_client import redis_client
 API_ENDPOINT = "/api/v1/quote"
 
 
-def test_read_quote_api_returns_200(client):
-    """Test that the /api/quote endpoint returns a 200 status code"""
+def test_read_quote_api_returns_200_on_cache_miss(client, mocker):
+    """
+    Test that the /api/quote endpoint returns a 200 status code when cache is empty.
+    """
+    mocker.patch.object(redis_client, "srandmember", return_value=None)
+
     response = client.get(API_ENDPOINT)
+
     assert response.status_code == 200
+    redis_client.srandmember.assert_called_once_with("quotes")
 
 
-def test_read_quote_api_returns_json(client):
-    """Test that the /api/quote endpoint returns a JSON response"""
+def test_read_quote_api_returns_json_on_cache_miss(client, mocker):
+    """
+    Test that the /api/quote endpoint returns a JSON response when cache is empty.
+    """
+    mocker.patch.object(redis_client, "srandmember", return_value=None)
+
     response = client.get(API_ENDPOINT)
+
     assert response.headers["Content-Type"] == "application/json"
+    redis_client.srandmember.assert_called_once_with("quotes")
 
 
-def test_read_quote_api_returns_correct_structure(client):
+def test_read_quote_api_returns_correct_structure_on_cache_miss(client, mocker):
     """
     Test that the /api/quote endpoint returns a JSON response
-    with the correct structure.
+    with the correct structure when cache is empty.
     """
+    mocker.patch.object(redis_client, "srandmember", return_value=None)
+
     response = client.get(API_ENDPOINT)
     data = response.json()
     assert "author" in data
     assert "text" in data
+    redis_client.srandmember.assert_called_once_with("quotes")
 
 
 def test_get_quote_with_cache_hit(client, mocker):
@@ -37,10 +52,12 @@ def test_get_quote_with_cache_hit(client, mocker):
     }
     cached_quote_json_string = json.dumps(cached_quote)
 
-    mocker.patch.object(redis_client, "lpop", return_value=cached_quote_json_string)
+    mocker.patch.object(
+        redis_client, "srandmember", return_value=cached_quote_json_string
+    )
 
     response = client.get(API_ENDPOINT)
 
     assert response.status_code == 200
     assert response.json() == cached_quote
-    redis_client.lpop.assert_called_once_with("quotes")
+    redis_client.srandmember.assert_called_once_with("quotes")

--- a/backend/tests/routers/test_quotes.py
+++ b/backend/tests/routers/test_quotes.py
@@ -1,6 +1,8 @@
 import json
+from app.core.redis_client import redis_client
 
 API_ENDPOINT = "/api/v1/quote"
+
 
 def test_read_quote_api_returns_200(client):
     """Test that the /api/quote endpoint returns a 200 status code"""
@@ -34,11 +36,11 @@ def test_get_quote_with_cache_hit(client, mocker):
         "text": "A quote from Redis.",
     }
     cached_quote_json_string = json.dumps(cached_quote)
-    mock_redis = mocker.patch('app.routers.quotes.redis_client')
-    mock_redis.get.return_value = cached_quote_json_string
+
+    mocker.patch.object(redis_client, "lpop", return_value=cached_quote_json_string)
 
     response = client.get(API_ENDPOINT)
 
     assert response.status_code == 200
     assert response.json() == cached_quote
-    mock_redis.lpop.assert_called_once_with("quotes")
+    redis_client.lpop.assert_called_once_with("quotes")

--- a/backend/tests/routers/test_quotes.py
+++ b/backend/tests/routers/test_quotes.py
@@ -1,5 +1,6 @@
-API_ENDPOINT = "/api/v1/quote"
+import json
 
+API_ENDPOINT = "/api/v1/quote"
 
 def test_read_quote_api_returns_200(client):
     """Test that the /api/quote endpoint returns a 200 status code"""
@@ -22,3 +23,22 @@ def test_read_quote_api_returns_correct_structure(client):
     data = response.json()
     assert "author" in data
     assert "text" in data
+
+
+def test_get_quote_with_cache_hit(client, mocker):
+    """
+    Test that Get /quote returns a quote from Redis when the cache is hit.
+    """
+    cached_quote = {
+        "author": "Cached Author",
+        "text": "A quote from Redis.",
+    }
+    cached_quote_json_string = json.dumps(cached_quote)
+    mock_redis = mocker.patch('app.routers.quotes.redis_client')
+    mock_redis.get.return_value = cached_quote_json_string
+
+    response = client.get(API_ENDPOINT)
+
+    assert response.status_code == 200
+    assert response.json() == cached_quote
+    mock_redis.lpop.assert_called_once_with("quotes")


### PR DESCRIPTION
This commit significantly refactors the quote retrieval endpoint for better scalability, efficiency, and maintainability.

The key changes are:

- **Implemented Cache Strategy:** The caching mechanism was create dusing `SET` with `SRANDMEMBER`. This treats the cache as a reusable pool of quotes rather than a consumable queue, maximizing the value of each generated quote and decoupling cache depletion from request volume.

- **Centralized Fallback Quotes:** The static fallback quotes were moved from an inline list in the router to a single source of truth. They are now loaded once at application startup from `knowledge_base/quotes.json`.

- **Updated Tests:** All related tests were updated to reflect the new `srandmember` logic, ensuring the endpoint's contract remains valid for both cache hit and cache miss scenarios. This refactoring was performed following TDD principles.